### PR TITLE
Auto-answer oh-my-zsh zshrc overwrite prompt

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -61,7 +61,7 @@ sleep 3
 
 # install oh-my-zsh
 echo -e "\n${BOLD}Installing Oh-My-Zsh...${NORMAL}"
-echo "y" | RUNZSH=no CHSH=no sh -c "$(curl --progress-bar -L https://raw.github.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
+RUNZSH=no CHSH=no OVERWRITE_CONFIRMATION=no sh -c "$(curl --progress-bar -L https://raw.github.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
 
 # create dotfiles_old in homedir
 if ! [ -d $olddir ]; then

--- a/install.sh
+++ b/install.sh
@@ -61,7 +61,7 @@ sleep 3
 
 # install oh-my-zsh
 echo -e "\n${BOLD}Installing Oh-My-Zsh...${NORMAL}"
-RUNZSH=no CHSH=no sh -c "$(curl --progress-bar -L https://raw.github.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
+echo "y" | RUNZSH=no CHSH=no sh -c "$(curl --progress-bar -L https://raw.github.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
 
 # create dotfiles_old in homedir
 if ! [ -d $olddir ]; then


### PR DESCRIPTION
## Summary
- Pipes `y` to the oh-my-zsh installer to automatically answer the "overwrite .zshrc?" prompt, preventing the terminal from hanging

## Test plan
- [ ] Run `install.sh` on a machine with an existing `.zshrc` and verify it completes without hanging
- [ ] Confirm `.zshrc` is overwritten by oh-my-zsh, then replaced by the dotfiles symlink
- [ ] Confirm original `.zshrc` is backed up to `~/.dotfiles_old/zshrc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)