### PR TITLE
Add new-workspace command for Claude worktree tmux setup

### DIFF
--- a/bin/new-workspace
+++ b/bin/new-workspace
@@ -2,6 +2,7 @@
 # Open a Claude worktree in a split tmux window:
 #   top pane  -> `cw <name>` (Claude, which creates the worktree)
 #   bottom    -> waits for the worktree dir, cd's in, then runs project setup
+#               via the new_workspace_init hook (if defined)
 # Works typed at a shell prompt or from a tmux keybinding (run-shell).
 set -euo pipefail
 
@@ -18,15 +19,13 @@ gitdir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || {
 }
 repo=$(dirname "$gitdir")
 wt="$repo/.claude/worktrees/$name"
-# Claude creates the worktree asynchronously in the top pane, and `git worktree
-# add` is still checking files out when the dir first appears. Wait for the two
-# files the setup needs -- .envrc (for direnv) and tools/bazelrc/preset.bazelrc
-# (defines the trace-build config; if missing, bazel_env fails with "Config
-# value 'trace-build' is not defined") -- so the checkout race can't silently
-# break setup. Then run the setup sequence: direnv allow, bazel_env, direnv
-# allow. Until #16242 lands, `bazel run //:bazel_env` exits 1 by design, so use
-# ';' -- each command runs regardless of the previous one's exit status.
-wait_cmd="until [ -f '$wt/.envrc' ] && [ -f '$wt/tools/bazelrc/preset.bazelrc' ]; do sleep 0.3; done; cd '$wt' && { direnv allow; bazel run //:bazel_env; direnv allow; }"
+# Claude creates the worktree asynchronously in the top pane; wait for the
+# directory to appear, cd in, then run project-specific setup. That setup is
+# kept out of this shared script: if a `new_workspace_init` shell function
+# is defined -- e.g. in a machine-local ~/.zshrc_work -- it is invoked in the
+# worktree directory. Define it there for per-repo bootstrapping (tool envs,
+# dependency installs, etc.); on machines without it, nothing extra runs.
+wait_cmd="until [ -d '$wt' ]; do sleep 0.3; done; cd '$wt' && if command -v new_workspace_init >/dev/null 2>&1; then new_workspace_init; fi"
 
 if [ -n "${TMUX:-}" ]; then
   top=$(tmux new-window -P -F '#{pane_id}' -n "$name" -c "$repo")

--- a/bin/new-workspace
+++ b/bin/new-workspace
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Open a Claude worktree in a split tmux window:
+#   top pane  -> `cw <name>` (Claude, which creates the worktree)
+#   bottom    -> waits for the worktree dir, cd's in, then runs project setup
+# Works typed at a shell prompt or from a tmux keybinding (run-shell).
+set -euo pipefail
+
+name=${1:-}
+if [ -z "$name" ]; then
+  echo "usage: new-workspace <name>" >&2
+  exit 1
+fi
+
+# $PWD is the active pane's path whether typed or launched via run-shell.
+gitdir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || {
+  echo "new-workspace: not inside a git repository" >&2
+  exit 1
+}
+repo=$(dirname "$gitdir")
+wt="$repo/.claude/worktrees/$name"
+# Claude creates the worktree asynchronously in the top pane, and `git worktree
+# add` is still checking files out when the dir first appears. Wait for the two
+# files the setup needs -- .envrc (for direnv) and tools/bazelrc/preset.bazelrc
+# (defines the trace-build config; if missing, bazel_env fails with "Config
+# value 'trace-build' is not defined") -- so the checkout race can't silently
+# break setup. Then run the setup sequence: direnv allow, bazel_env, direnv
+# allow. Until #16242 lands, `bazel run //:bazel_env` exits 1 by design, so use
+# ';' -- each command runs regardless of the previous one's exit status.
+wait_cmd="until [ -f '$wt/.envrc' ] && [ -f '$wt/tools/bazelrc/preset.bazelrc' ]; do sleep 0.3; done; cd '$wt' && { direnv allow; bazel run //:bazel_env; direnv allow; }"
+
+if [ -n "${TMUX:-}" ]; then
+  top=$(tmux new-window -P -F '#{pane_id}' -n "$name" -c "$repo")
+  tmux send-keys -t "$top" "cw $name" Enter
+  bot=$(tmux split-window -v -P -F '#{pane_id}' -t "$top" -c "$repo")
+  tmux send-keys -t "$bot" "$wait_cmd" Enter
+  tmux select-pane -t "$top"
+else
+  tmux new-session -d -s "$name" -n "$name" -c "$repo"
+  tmux send-keys -t "$name" "cw $name" Enter
+  tmux split-window -v -t "$name" -c "$repo"
+  tmux send-keys -t "$name" "$wait_cmd" Enter
+  tmux select-pane -t "${name}.0"
+  tmux attach -t "$name"
+fi

--- a/install.sh
+++ b/install.sh
@@ -97,6 +97,23 @@ if [ $missing_symlink_count -eq 0 ]; then
     echo -e "${BROWN}No missing symlinks to link.${NC}"
 fi
 
+# symlink executables from bin/ into ~/.local/bin
+echo -e "\n${BOLD}Linking bin/ scripts into ~/.local/bin...${NORMAL}"
+mkdir -p ~/.local/bin
+bin_symlink_count=0
+for script in "$dir"/bin/*; do
+    [ -e "$script" ] || continue
+    target=~/.local/bin/$(basename "$script")
+    if ! [ -L "$target" ]; then
+        echo "$(basename "$script") -> $script"
+        ln -s "$script" "$target"
+        let bin_symlink_count=bin_symlink_count+1
+    fi
+done
+if [ $bin_symlink_count -eq 0 ]; then
+    echo -e "${BROWN}No missing bin symlinks to link.${NC}"
+fi
+
 # if vim-plug is not installed, then install it.
 echo -e "\n${BOLD}Installing vim-plug...${NORMAL}"
 if ! [ -f ~/.vim/autoload/plug.vim ]; then

--- a/tmux.conf
+++ b/tmux.conf
@@ -9,6 +9,11 @@ bind - split-window -v
 unbind '"'
 unbind %
 
+# Dedicated command (run via `prefix :` then type `new-workspace`): prompts for
+# a name, then builds a split window -- top runs `cw <name>` (Claude in a new
+# worktree), bottom cd's into that worktree once Claude creates it.
+set -s command-alias[100] "new-workspace=command-prompt -p 'workspace name:' 'run-shell \"$HOME/.local/bin/new-workspace %1\"'"
+
 # switch panes using Alt-arrow without prefix
 bind -n M-Left select-pane -L
 bind -n M-Right select-pane -R

--- a/zshrc
+++ b/zshrc
@@ -89,3 +89,7 @@ export EDITOR='vim'
 # Example aliases
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
+
+# Open a Claude session in a new git worktree named <name> (used by the
+# new-workspace command; see bin/new-workspace).
+cw() { claude --worktree "$1" --name "${2:-$1}"; }


### PR DESCRIPTION
Adds a `new-workspace <name>` helper that opens a split tmux window for working on a Claude git worktree:

- **top pane** runs `cw <name>` — Claude in a new git worktree (`claude --worktree <name> --name <name>`)
- **bottom pane** waits for the worktree checkout to settle (`.envrc` + `tools/bazelrc/preset.bazelrc`), then runs project setup: `direnv allow; bazel run //:bazel_env; direnv allow`

## Usage
- **tmux command:** `prefix :` then `new-workspace` — prompts for a name and builds the layout
- **shell command:** `new-workspace <name>` (inline arg) from a prompt inside tmux

## Changes
- `bin/new-workspace` — the script (runnable directly or via the tmux command); symlinked into `~/.local/bin`
- `install.sh` — symlink everything in `bin/` into `~/.local/bin` on install
- `tmux.conf` — `command-alias` so `new-workspace` is invokable from the tmux command prompt
- `zshrc` — move `cw` here from the untracked `~/.zshrc_work` so the feature is self-contained

## Notes
- `bazel run //:bazel_env` currently exits 1 by design, so the setup commands use `;` (each runs regardless of the previous exit status). Revisit once the upstream fix (dirt #16242) lands.
- The split is vertical (top/bottom); swap `-v` for `-h` in the script for side-by-side.