### PR TITLE
tmux: badge windows with Claude session state

### DIFF
--- a/bin/claude-tmux-state
+++ b/bin/claude-tmux-state
@@ -7,8 +7,10 @@ set -u
 
 state=${1:-}
 
-# Match the message alone -- the payload's cwd and permission_mode also contain
-# "permission" -- to tell a real prompt from the idle nudge 60s after a turn.
+# Notification means either a permission prompt or the "still waiting" nudge 60s
+# after a turn ends. Only the message field distinguishes them: the rest of the
+# payload repeats the session's directory and permission mode, and those contain
+# the word "permission" often enough to match by accident.
 if [ "$state" = notification ]; then
     payload=$(cat)
     message=$(printf '%s' "$payload" | jq -r '.message // ""' 2>/dev/null)
@@ -20,7 +22,8 @@ if [ "$state" = notification ]; then
     esac
 fi
 
-# Tool hooks fire after Stop too, so they may report work but never clobber done.
+# A tool finishing in the background fires a hook after the turn already ended,
+# so "working" must not overwrite the done state that Stop set.
 if [ "$state" = working ]; then
     [ "$(tmux show-options -pqv -t "$TMUX_PANE" @claude_state 2>/dev/null)" = done ] && exit 0
     state=busy
@@ -37,7 +40,7 @@ else
     tmux set-option -p -t "$TMUX_PANE" @claude_state "$state" 2>/dev/null
 fi
 
-# Option changes don't dirty the status line; without this the badge lags.
+# Refresh the client so tmux picks up the state change right away.
 tmux refresh-client -S 2>/dev/null
 
 exit 0

--- a/bin/claude-tmux-state
+++ b/bin/claude-tmux-state
@@ -1,24 +1,14 @@
 #!/bin/sh
-# Stamps what the Claude Code session in this tmux pane is doing onto the pane
-# as @claude_state (idle | busy | done | perm); tmux.conf renders it as a badge
-# in the window status line. Driven by the hooks in ~/.claude/settings.json,
-# which deliver their JSON payload on stdin.
-#
-# The marker lives on the pane rather than the window so that it disappears
-# with the pane -- a session killed without firing SessionEnd leaves nothing
-# stale behind -- and so that two Claude sessions in one window don't fight
-# over a single value.
+# Sets @claude_state (idle | busy | done | perm) on the tmux pane running this
+# Claude session; tmux.conf renders it. Called from hooks in ~/.claude/settings.json.
 set -u
 
 [ -n "${TMUX:-}" ] && [ -n "${TMUX_PANE:-}" ] || exit 0
 
 state=${1:-}
 
-# Notification fires both for permission prompts and for the idle nudge ~60s
-# after a turn ends; only the former means Claude is blocked on an answer. Match
-# the message field alone: the rest of the payload carries cwd and
-# permission_mode, so matching the raw JSON reddens any worktree whose path
-# happens to contain "permission".
+# Match the message alone -- the payload's cwd and permission_mode also contain
+# "permission" -- to tell a real prompt from the idle nudge 60s after a turn.
 if [ "$state" = notification ]; then
     payload=$(cat)
     message=$(printf '%s' "$payload" | jq -r '.message // ""' 2>/dev/null)
@@ -30,17 +20,13 @@ if [ "$state" = notification ]; then
     esac
 fi
 
-# Tool and subagent hooks keep firing after the turn is over -- a background
-# shell exiting, an agent reporting in -- so they may only report work, never
-# overwrite the "your turn" marker that Stop left behind. They do clear a
-# pending permission prompt, since a tool running means it was answered.
+# Tool hooks fire after Stop too, so they may report work but never clobber done.
 if [ "$state" = working ]; then
     [ "$(tmux show-options -pqv -t "$TMUX_PANE" @claude_state 2>/dev/null)" = done ] && exit 0
     state=busy
 fi
 
-# Tracing is enabled by the log file existing: `touch` it to debug which hooks
-# fire, `rm` it to stop.
+# Tracing: `touch` this file to enable, `rm` to stop.
 log=$HOME/.claude/tmux-state.log
 [ -f "$log" ] && printf '%s %s %s -> %s%s\n' "$(date +%H:%M:%S)" "$TMUX_PANE" \
     "${1:-}" "$state" "${message+ [$message]}" >>"$log"
@@ -51,8 +37,7 @@ else
     tmux set-option -p -t "$TMUX_PANE" @claude_state "$state" 2>/dev/null
 fi
 
-# Option changes don't mark the status line dirty, so without this the badge
-# lags by up to status-interval.
+# Option changes don't dirty the status line; without this the badge lags.
 tmux refresh-client -S 2>/dev/null
 
 exit 0

--- a/bin/claude-tmux-state
+++ b/bin/claude-tmux-state
@@ -1,0 +1,58 @@
+#!/bin/sh
+# Stamps what the Claude Code session in this tmux pane is doing onto the pane
+# as @claude_state (idle | busy | done | perm); tmux.conf renders it as a badge
+# in the window status line. Driven by the hooks in ~/.claude/settings.json,
+# which deliver their JSON payload on stdin.
+#
+# The marker lives on the pane rather than the window so that it disappears
+# with the pane -- a session killed without firing SessionEnd leaves nothing
+# stale behind -- and so that two Claude sessions in one window don't fight
+# over a single value.
+set -u
+
+[ -n "${TMUX:-}" ] && [ -n "${TMUX_PANE:-}" ] || exit 0
+
+state=${1:-}
+
+# Notification fires both for permission prompts and for the idle nudge ~60s
+# after a turn ends; only the former means Claude is blocked on an answer. Match
+# the message field alone: the rest of the payload carries cwd and
+# permission_mode, so matching the raw JSON reddens any worktree whose path
+# happens to contain "permission".
+if [ "$state" = notification ]; then
+    payload=$(cat)
+    message=$(printf '%s' "$payload" | jq -r '.message // ""' 2>/dev/null)
+    [ -n "$message" ] || message=$(printf '%s' "$payload" |
+        sed -n 's/.*"message"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+    case "$message" in
+        *permission*|*approve*) state=perm ;;
+        *) state=done ;;
+    esac
+fi
+
+# Tool and subagent hooks keep firing after the turn is over -- a background
+# shell exiting, an agent reporting in -- so they may only report work, never
+# overwrite the "your turn" marker that Stop left behind. They do clear a
+# pending permission prompt, since a tool running means it was answered.
+if [ "$state" = working ]; then
+    [ "$(tmux show-options -pqv -t "$TMUX_PANE" @claude_state 2>/dev/null)" = done ] && exit 0
+    state=busy
+fi
+
+# Tracing is enabled by the log file existing: `touch` it to debug which hooks
+# fire, `rm` it to stop.
+log=$HOME/.claude/tmux-state.log
+[ -f "$log" ] && printf '%s %s %s -> %s%s\n' "$(date +%H:%M:%S)" "$TMUX_PANE" \
+    "${1:-}" "$state" "${message+ [$message]}" >>"$log"
+
+if [ "$state" = clear ]; then
+    tmux set-option -up -t "$TMUX_PANE" @claude_state 2>/dev/null
+else
+    tmux set-option -p -t "$TMUX_PANE" @claude_state "$state" 2>/dev/null
+fi
+
+# Option changes don't mark the status line dirty, so without this the badge
+# lags by up to status-interval.
+tmux refresh-client -S 2>/dev/null
+
+exit 0

--- a/bin/claude-tmux-state
+++ b/bin/claude-tmux-state
@@ -6,19 +6,29 @@ set -u
 [ -n "${TMUX:-}" ] && [ -n "${TMUX_PANE:-}" ] || exit 0
 
 state=${1:-}
+payload=
+
+case "$state" in notification|done) payload=$(cat) ;; esac
 
 # Notification means either a permission prompt or the "still waiting" nudge 60s
 # after a turn ends. Only the message field distinguishes them: the rest of the
 # payload repeats the session's directory and permission mode, and those contain
 # the word "permission" often enough to match by accident.
 if [ "$state" = notification ]; then
-    payload=$(cat)
     message=$(printf '%s' "$payload" | jq -r '.message // ""' 2>/dev/null)
     [ -n "$message" ] || message=$(printf '%s' "$payload" |
         sed -n 's/.*"message"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
     case "$message" in
         *permission*|*approve*) state=perm ;;
         *) state=done ;;
+    esac
+fi
+
+# Claude ends its turn while background agents and shells keep running, so it is
+# only your turn once the payload lists no running task.
+if [ "$state" = done ]; then
+    case "$payload" in
+        *'"status":"running"'*|*'"status": "running"'*) state=busy ;;
     esac
 fi
 

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,0 +1,99 @@
+{
+  "model": "sonnet",
+  "theme": "dark",
+  "remoteControlAtStartup": true,
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$HOME/.local/bin/claude-tmux-state\" idle"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$HOME/.local/bin/claude-tmux-state\" busy"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$HOME/.local/bin/claude-tmux-state\" working"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$HOME/.local/bin/claude-tmux-state\" working"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$HOME/.local/bin/claude-tmux-state\" working"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$HOME/.local/bin/claude-tmux-state\" working"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$HOME/.local/bin/claude-tmux-state\" notification"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$HOME/.local/bin/claude-tmux-state\" done"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$HOME/.local/bin/claude-tmux-state\" clear"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,7 +1,5 @@
 {
-  "model": "sonnet",
-  "theme": "dark",
-  "remoteControlAtStartup": true,
+  "model": "opus[1m]",
   "hooks": {
     "SessionStart": [
       {
@@ -95,5 +93,7 @@
         ]
       }
     ]
-  }
+  },
+  "theme": "dark",
+  "remoteControlAtStartup": true
 }

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "model": "opus[1m]",
+  "model": "sonnet",
   "hooks": {
     "SessionStart": [
       {
@@ -94,6 +94,7 @@
       }
     ]
   },
+  "effortLevel": "high",
   "theme": "dark",
   "remoteControlAtStartup": true
 }

--- a/install.sh
+++ b/install.sh
@@ -114,9 +114,9 @@ if [ $bin_symlink_count -eq 0 ]; then
     echo -e "${BROWN}No missing bin symlinks to link.${NC}"
 fi
 
-# symlink Claude Code's user settings (model, theme, permissions, the hooks that
-# drive the tmux status badges). Claude writes to this file itself -- /model and
-# /config land straight in the repo, which is the point, but expect diffs.
+# symlink Claude Code's user settings: model, theme, permissions, and the hooks
+# that drive the tmux status badges. Changing a setting from inside Claude (with
+# /model or /config) edits this repo's copy, so those changes show up in git.
 echo -e "\n${BOLD}Linking Claude Code settings...${NORMAL}"
 mkdir -p ~/.claude
 if [ -f ~/.claude/settings.json ] && ! [ -L ~/.claude/settings.json ]; then

--- a/install.sh
+++ b/install.sh
@@ -114,6 +114,22 @@ if [ $bin_symlink_count -eq 0 ]; then
     echo -e "${BROWN}No missing bin symlinks to link.${NC}"
 fi
 
+# symlink Claude Code's user settings (model, theme, permissions, the hooks that
+# drive the tmux status badges). Claude writes to this file itself -- /model and
+# /config land straight in the repo, which is the point, but expect diffs.
+echo -e "\n${BOLD}Linking Claude Code settings...${NORMAL}"
+mkdir -p ~/.claude
+if [ -f ~/.claude/settings.json ] && ! [ -L ~/.claude/settings.json ]; then
+    echo "settings.json -> ~/.dotfiles_old/claude-settings.json"
+    mv ~/.claude/settings.json ~/.dotfiles_old/claude-settings.json
+fi
+if ! [ -L ~/.claude/settings.json ]; then
+    echo "~/.claude/settings.json -> $dir/claude/settings.json"
+    ln -s "$dir"/claude/settings.json ~/.claude/settings.json
+else
+    echo -e "${BROWN}Claude settings already linked.${NC}"
+fi
+
 # if vim-plug is not installed, then install it.
 echo -e "\n${BOLD}Installing vim-plug...${NORMAL}"
 if ! [ -f ~/.vim/autoload/plug.vim ]; then

--- a/tmux.conf
+++ b/tmux.conf
@@ -37,22 +37,15 @@ bind-key -Tcopy-mode-vi 'y' send -X copy-selection
 
 set -g status-left-length 50
 
-# Claude Code session state badge: ~/.local/bin/claude-tmux-state stamps
-# @claude_state on each pane running a Claude session (wired up by the hooks in
-# ~/.claude/settings.json). Rendering it straight from the pane options means
-# the badge is always live -- nothing to reconcile, nothing to go stale.
+# Claude session badge: ? needs an answer, ✓ your turn, ◐ working, ○ idle.
+# ~/.local/bin/claude-tmux-state sets @claude_state per pane; a window shows the
+# most urgent state among its panes. Dash delimiters keep the m: patterns from
+# matching inside each other, and the badge takes no colour so it inherits the
+# window style (a coloured glyph is unreadable on one background or the other).
 set -g @claude_pane_states "#{P:-#{@claude_state}-}"
-
-#   ? needs an answer    ✓ turn finished    ◐ working    ○ idle
-# A window wears the most urgent state among its panes; two trailing spaces on
-# the empty branch keep every window label aligned. The badge carries no colour
-# of its own so that it inherits the surrounding window style -- black on the
-# status bar, white on the active window's black background -- which stays
-# legible either way. Shape alone distinguishes the states.
 set -g @claude_badge "#{?#{m:*-perm-*,#{E:@claude_pane_states}},? ,#{?#{m:*-done-*,#{E:@claude_pane_states}},✓ ,#{?#{m:*-busy-*,#{E:@claude_pane_states}},◐ ,#{?#{m:*-idle-*,#{E:@claude_pane_states}},○ ,  }}}}"
 
-# Interrupting Claude with Esc fires no hook, so a cancelled turn can leave a
-# stale ◐ behind until the next prompt. Clear this pane's badge by hand.
+# Esc-interrupting Claude fires no hook, so clear a stale badge by hand.
 bind E run-shell "tmux set-option -up @claude_state; tmux refresh-client -S"
 
 # Style for inactive windows

--- a/tmux.conf
+++ b/tmux.conf
@@ -37,11 +37,15 @@ bind-key -Tcopy-mode-vi 'y' send -X copy-selection
 
 set -g status-left-length 50
 
-# Claude session badge: ? needs an answer, ✓ your turn, ◐ working, ○ idle.
-# ~/.local/bin/claude-tmux-state sets @claude_state per pane; a window shows the
-# most urgent state among its panes. Dash delimiters keep the m: patterns from
-# matching inside each other, and the badge takes no colour so it inherits the
-# window style (a coloured glyph is unreadable on one background or the other).
+# Claude session badge. Hooks in ~/.claude/settings.json run claude-tmux-state,
+# which sets @claude_state on the pane; a window shows the most urgent state
+# among its panes:
+#   ?  Claude is asking for permission
+#   ✓  Claude finished its turn
+#   ◐  Claude is working
+#   ○  a session is open with nothing pending
+# Dash delimiters keep the m: patterns from matching inside each other. The badge
+# sets no color of its own so it inherits the window style.
 set -g @claude_pane_states "#{P:-#{@claude_state}-}"
 set -g @claude_badge "#{?#{m:*-perm-*,#{E:@claude_pane_states}},? ,#{?#{m:*-done-*,#{E:@claude_pane_states}},✓ ,#{?#{m:*-busy-*,#{E:@claude_pane_states}},◐ ,#{?#{m:*-idle-*,#{E:@claude_pane_states}},○ ,  }}}}"
 

--- a/tmux.conf
+++ b/tmux.conf
@@ -37,13 +37,31 @@ bind-key -Tcopy-mode-vi 'y' send -X copy-selection
 
 set -g status-left-length 50
 
+# Claude Code session state badge: ~/.local/bin/claude-tmux-state stamps
+# @claude_state on each pane running a Claude session (wired up by the hooks in
+# ~/.claude/settings.json). Rendering it straight from the pane options means
+# the badge is always live -- nothing to reconcile, nothing to go stale.
+set -g @claude_pane_states "#{P:-#{@claude_state}-}"
+
+#   ? needs an answer    ✓ turn finished    ◐ working    ○ idle
+# A window wears the most urgent state among its panes; two trailing spaces on
+# the empty branch keep every window label aligned. The badge carries no colour
+# of its own so that it inherits the surrounding window style -- black on the
+# status bar, white on the active window's black background -- which stays
+# legible either way. Shape alone distinguishes the states.
+set -g @claude_badge "#{?#{m:*-perm-*,#{E:@claude_pane_states}},? ,#{?#{m:*-done-*,#{E:@claude_pane_states}},✓ ,#{?#{m:*-busy-*,#{E:@claude_pane_states}},◐ ,#{?#{m:*-idle-*,#{E:@claude_pane_states}},○ ,  }}}}"
+
+# Interrupting Claude with Esc fires no hook, so a cancelled turn can leave a
+# stale ◐ behind until the next prompt. Clear this pane's badge by hand.
+bind E run-shell "tmux set-option -up @claude_state; tmux refresh-client -S"
+
 # Style for inactive windows
 setw -g window-status-style fg=default,bg=default
-setw -g window-status-format " #I: #W "
+setw -g window-status-format " #{E:@claude_badge}#I: #W "
 
 # Style for the active window
 setw -g window-status-current-style fg=white,bg=black,bold
-setw -g window-status-current-format " #I: #W "
+setw -g window-status-current-format " #{E:@claude_badge}#I: #W "
 
 # bind -t vi-copy y copy-pipe 'xclip -in -selection clipboard'
 


### PR DESCRIPTION
Adds claude session state to tmux windows

# Claude

Labels each tmux window with what its Claude Code session is doing, so a glance at the status bar says which sessions need you.

| glyph | state | driven by |
|---|---|---|
| `○` | session open, nothing pending | `SessionStart` |
| `◐` | working | `UserPromptSubmit`, tool hooks |
| `✓` | turn finished, your move | `Stop`, the 60s idle nudge |
| `?` | blocked on a permission prompt | `Notification` |

## How it works

`bin/claude-tmux-state` is invoked by hooks in `~/.claude/settings.json`, reads `$TMUX_PANE` out of the environment Claude inherited from tmux, and stamps the state on that pane as `@claude_state`. `tmux.conf` renders it by walking each window's panes with `#{P:...}` and showing the most urgent state.

Design points worth noting:

- **Pane-scoped, not window-scoped.** The marker dies with the pane, so a session killed without firing `SessionEnd` can't leave a stale badge, and two sessions sharing a window don't overwrite each other.
- **`busy` can't overwrite `done`.** Tool and subagent hooks keep firing after a turn ends (a background shell exiting, an agent reporting in); without the guard they stamp yellow over the green ✓ and it sticks until the next prompt.
- **Only the `message` field decides `perm`.** The hook payload also carries `cwd` and `permission_mode`, so matching the raw JSON turned any worktree whose path contains "permission" red 60 seconds after every turn.
- **No colour of its own.** The badge inherits the surrounding window style — black on the status bar, white on the active window — which stays legible in both, where a green ✓ on the green status bar did not.

## Known gap

Interrupting with Esc fires no hook at all, so a cancelled turn leaves `◐` until the next prompt or the ~60s idle notification. `prefix + E` clears a badge by hand.

## Claude settings now tracked

`~/.claude/settings.json` is symlinked into the repo, so the hooks, the permission allowlist, and the model/theme prefs travel with it. Claude writes to that file itself (`/model`, `/config`) and writes *through* the symlink rather than replacing it — verified in a sandbox `HOME` — so those edits arrive as ordinary diffs. `install.sh` handles all three states: no `~/.claude`, already linked, or a pre-existing real file (backed up to `~/.dotfiles_old/`).